### PR TITLE
Bug 1069458 - Typo in Kit Builder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -210,7 +210,7 @@ What will participants make? What's the end result or finished product? A web pa
             </div>
 
             <div class="form-group">
-              <label class="control-label" for="kitPreperation">Preperation</label>
+              <label class="control-label" for="kitPreperation">Preparation</label>
               <textarea class="form-control" id="kitPreperation" name="kitPreperation" rows="5" required>
 Are any special materials required? What tools will participants need? Should anything be set up in advance? Is there any software to install, or specific technical requirements?
               </textarea>


### PR DESCRIPTION
The typo in the word "Preperation" is corrected to "Preparation". A bug in index.html.
